### PR TITLE
Add BB-BC configuration support

### DIFF
--- a/algorithms/big_bang_big_crunch.py
+++ b/algorithms/big_bang_big_crunch.py
@@ -91,6 +91,13 @@ class BigBangBigCrunchOptimiser(Optimiser):
             self.objective_function, 1, self.population
         )
 
+        best = np.argmin(self.fitnesses)
+        self.best_solution = self.population[best]
+
+        if not self.calc_center_of_mass:
+            self.center_of_mass = self.best_solution
+            return
+
         sum_of_mass = 0
         sum_of_mass_points = 0
 
@@ -106,8 +113,5 @@ class BigBangBigCrunchOptimiser(Optimiser):
 
         self.big_bang()
         self.big_crunch()
-
-        best = np.argmin(self.fitnesses)
-        self.best_solution = self.population[best]
 
         print(f"\rIteration: {self.iteration}/{self.max_iterations} ", end="")

--- a/algorithms/big_bang_big_crunch.py
+++ b/algorithms/big_bang_big_crunch.py
@@ -45,9 +45,15 @@ class BigBangBigCrunchOptimiser(Optimiser):
         Returns:
             numpy.ndarray: The coordinates of the new point.
         """
+        deviation = self.val_max * np.random.normal(size=self.dimensions)
+
+        if not self.deviation_fixed:
+            deviation /= self.iteration
+
+        new_point = self.center_of_mass + deviation
+
         return np.clip(
-            self.center_of_mass
-            + (self.val_max * np.random.normal(size=self.dimensions)) / self.iteration,
+            new_point,
             self.val_min,
             self.val_max,
         )

--- a/algorithms/big_bang_big_crunch.py
+++ b/algorithms/big_bang_big_crunch.py
@@ -41,6 +41,8 @@ class BigBangBigCrunchOptimiser(Optimiser):
         """
         Generates a new point in the search space using a modified
         Gaussian distribution centered around the current best location.
+        If the deviation is fixed, the iteration number will not have
+        any influence on the deviation values.
 
         Returns:
             numpy.ndarray: The coordinates of the new point.
@@ -92,6 +94,8 @@ class BigBangBigCrunchOptimiser(Optimiser):
         It first evaluates the fitness of every point, then weights each point's
         position by its inverse fitness (mass) to find the weighted average
         location of the entire population.
+        If calculation of the center of mass is disabled, then the center of mass
+        is set to the best solution instead.
         """
         self.fitnesses = self.parallel_evaluate(self.population)
 


### PR DESCRIPTION
For the BB-BC optimisation algorithm:
- `self.deviation_fixed` is now used
  - If set to `True`, the iteration number will not alter the deviation values
  - If set to `False` (default), the deviation values are divided by the iteration number
- `self.calc_center_of_mass` is now used
  - If set to `True`, the center of mass is calculated  normally (the center of "mass" of all points)
  - If set to `False`, the center of mass is not calculated, and instead is set to the current best solution